### PR TITLE
Update the package installation path, img2dataset

### DIFF
--- a/subset/COYO-Labeled-300M/download/README.md
+++ b/subset/COYO-Labeled-300M/download/README.md
@@ -1,5 +1,5 @@
 # Notice
-Official img2dataset library now support list of integer, float attribute in tfrecord. 
+Official img2dataset(>=1.34.0) library now support list of integer, float attribute in tfrecord. 
 
 ## Download the metadata
 * Download metadata files from Huggingface Dataset

--- a/subset/COYO-Labeled-300M/download/README.md
+++ b/subset/COYO-Labeled-300M/download/README.md
@@ -16,7 +16,7 @@ Official img2dataset(>=1.34.0) library now support list of integer, float attrib
 ## Download the images with img2dataset
 * [img2dataset](https://github.com/rom1504/img2dataset) can easily download and store to [webdataset](https://github.com/webdataset/webdataset) or tfrecord format for large-scale distributed training.
   * Nov 10, 2022 : We are currently using a custom [img2dataset library](https://github.com/justHungryMan/img2dataset). Please see notice.
-  * Nov 16  2022 : Official img2dataset library now support list of integer, float attribute in tfrecord. We updated the img2dataset package path.
+  * Nov 16  2022 : Official img2dataset(>=1.34.0) library now support list of integer, float attribute in tfrecord. We updated the img2dataset package path.
 
 ### Download using Google Cloud Dataproc
 * [Dataproc](https://cloud.google.com/dataproc) is a fully managed and highly scalable service for running Apache Spark and 30+ open source tools. 

--- a/subset/COYO-Labeled-300M/download/README.md
+++ b/subset/COYO-Labeled-300M/download/README.md
@@ -16,7 +16,7 @@ Official img2dataset library now support list of integer, float attribute in tfr
 ## Download the images with img2dataset
 * [img2dataset](https://github.com/rom1504/img2dataset) can easily download and store to [webdataset](https://github.com/webdataset/webdataset) or tfrecord format for large-scale distributed training.
   * Nov 10, 2022 : We are currently using a custom [img2dataset library](https://github.com/justHungryMan/img2dataset). Please see notice.
-  * Nov 16  2022 : Official img2dataset library support list of integer, float attribute in tfrecord.
+  * Nov 16  2022 : Official img2dataset library now support list of integer, float attribute in tfrecord. We updated the img2dataset package path.
 
 ### Download using Google Cloud Dataproc
 * [Dataproc](https://cloud.google.com/dataproc) is a fully managed and highly scalable service for running Apache Spark and 30+ open source tools. 

--- a/subset/COYO-Labeled-300M/download/README.md
+++ b/subset/COYO-Labeled-300M/download/README.md
@@ -1,5 +1,5 @@
 # Notice
-Official img2dataset library support list of integer of float attribute in tfrecord now. 
+Official img2dataset library now support list of integer, float attribute in tfrecord. 
 
 ## Download the metadata
 * Download metadata files from Huggingface Dataset
@@ -16,7 +16,7 @@ Official img2dataset library support list of integer of float attribute in tfrec
 ## Download the images with img2dataset
 * [img2dataset](https://github.com/rom1504/img2dataset) can easily download and store to [webdataset](https://github.com/webdataset/webdataset) or tfrecord format for large-scale distributed training.
   * Nov 10, 2022 : We are currently using a custom [img2dataset library](https://github.com/justHungryMan/img2dataset). Please see notice.
-  * Nov 16  2022 : Official img2dataset library support list of integer of float attribute in tfrecord.
+  * Nov 16  2022 : Official img2dataset library support list of integer, float attribute in tfrecord.
 
 ### Download using Google Cloud Dataproc
 * [Dataproc](https://cloud.google.com/dataproc) is a fully managed and highly scalable service for running Apache Spark and 30+ open source tools. 

--- a/subset/COYO-Labeled-300M/download/README.md
+++ b/subset/COYO-Labeled-300M/download/README.md
@@ -1,6 +1,5 @@
 # Notice
-Since official img2dataset library doesn't support list of integer or float attribute in tfrecord, we now use custom img2dataset library.  
-We are waiting for accepting pull request and will notice as soon as it is updated.
+Official img2dataset library support list of integer of float attribute in tfrecord now. 
 
 ## Download the metadata
 * Download metadata files from Huggingface Dataset
@@ -16,7 +15,8 @@ We are waiting for accepting pull request and will notice as soon as it is updat
 
 ## Download the images with img2dataset
 * [img2dataset](https://github.com/rom1504/img2dataset) can easily download and store to [webdataset](https://github.com/webdataset/webdataset) or tfrecord format for large-scale distributed training.
-* Nov 10, 2022 : We are currently using a custom [img2dataset library](https://github.com/justHungryMan/img2dataset). Please see notice.
+  * Nov 10, 2022 : We are currently using a custom [img2dataset library](https://github.com/justHungryMan/img2dataset). Please see notice.
+  * Nov 16  2022 : Official img2dataset library support list of integer of float attribute in tfrecord.
 
 ### Download using Google Cloud Dataproc
 * [Dataproc](https://cloud.google.com/dataproc) is a fully managed and highly scalable service for running Apache Spark and 30+ open source tools. 

--- a/subset/COYO-Labeled-300M/download/dataproc/dataproc-initialization.sh
+++ b/subset/COYO-Labeled-300M/download/dataproc/dataproc-initialization.sh
@@ -3,7 +3,7 @@
 # Install img2dataset
 pip install --upgrade gcsfs
 pip install tensorflow tensorflow_io
-pip install git+https://github.com/justHungryMan/img2dataset
+pip install img2dataset
 
 
 

--- a/subset/COYO-Labeled-300M/download/dataproc/dataproc-initialization.sh
+++ b/subset/COYO-Labeled-300M/download/dataproc/dataproc-initialization.sh
@@ -1,9 +1,9 @@
 #/bin/bash
 
 # Install img2dataset
+pip install img2dataset>=1.34.0
 pip install --upgrade gcsfs
 pip install tensorflow tensorflow_io
-pip install img2dataset
 
 
 


### PR DESCRIPTION
Since img2dataset support list of integer, float attribute in tfreocord, see [here](https://github.com/rom1504/img2dataset/pull/217), we need to update the img2dataset package path.

